### PR TITLE
feat: Implement prospects display on dashboard with pagination

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -35,11 +35,13 @@ def create_app(config_name='default'): # config_name is no longer used but kept 
     from app.api.proposals import proposals_bp
     from app.api.data_sources import data_sources_bp
     from app.api.scrapers import scrapers_bp
+    from app.api.prospects import prospects_bp # Import the new blueprint
 
     app.register_blueprint(main_bp, url_prefix='/api')
     app.register_blueprint(proposals_bp, url_prefix='/api/proposals')
     app.register_blueprint(data_sources_bp, url_prefix='/api/data-sources')
     app.register_blueprint(scrapers_bp, url_prefix='/api/data-sources') # Scraper routes are under data-sources
+    app.register_blueprint(prospects_bp) # Register the new blueprint (uses url_prefix from its definition)
 
     # Register error handlers if defined in api.errors
     try:

--- a/app/api/prospects.py
+++ b/app/api/prospects.py
@@ -1,0 +1,48 @@
+from flask import Blueprint, jsonify, request
+from app.database.crud import get_prospects_paginated
+from app.utils.logger import logger
+
+prospects_bp = Blueprint('prospects_api', __name__, url_prefix='/api/prospects')
+
+@prospects_bp.route('/', methods=['GET'])
+def get_prospects_route():
+    logger.info("Received request for /api/prospects/")
+    try:
+        page = request.args.get('page', 1, type=int)
+        limit = request.args.get('limit', 10, type=int)
+
+        if page <= 0:
+            logger.error(f"Invalid page number: {page}. Must be > 0.")
+            return jsonify({"error": "Page number must be positive"}), 400
+        if limit <= 0:
+            logger.error(f"Invalid limit value: {limit}. Must be > 0.")
+            return jsonify({"error": "Limit must be positive"}), 400
+        
+        logger.debug(f"Requesting prospects with page={page}, limit={limit}")
+        results = get_prospects_paginated(page=page, per_page=limit)
+
+        if results is None:
+            # This case might occur if get_prospects_paginated itself returns None due to internal validation
+            # or a database error that it handles by returning None.
+            logger.error(f"Failed to retrieve prospects for page={page}, limit={limit}. get_prospects_paginated returned None.")
+            return jsonify({"error": "Failed to retrieve prospects. Check server logs."}), 500
+
+        prospect_items_dict = [prospect.to_dict() for prospect in results["items"]]
+        
+        response_data = {
+            "data": prospect_items_dict,
+            "total": results["total"],
+            "totalPages": results["total_pages"],
+            "currentPage": results["page"],
+            "perPage": results["per_page"]
+        }
+        
+        logger.info(f"Successfully retrieved {len(prospect_items_dict)} prospects for page {page}.")
+        return jsonify(response_data), 200
+
+    except ValueError as ve:
+        logger.error(f"ValueError in request arguments: {ve}", exc_info=True)
+        return jsonify({"error": "Invalid parameter type. 'page' and 'limit' must be integers."}), 400
+    except Exception as e:
+        logger.error(f"An unexpected error occurred in /api/prospects/: {e}", exc_info=True)
+        return jsonify({"error": "An unexpected error occurred. Please try again later."}), 500

--- a/frontend-react/src/tailwind-output.css
+++ b/frontend-react/src/tailwind-output.css
@@ -608,10 +608,6 @@ video {
   position: static;
 }
 
-.fixed {
-  position: fixed;
-}
-
 .absolute {
   position: absolute;
 }
@@ -630,14 +626,6 @@ video {
 
 .right-2 {
   right: 0.5rem;
-}
-
-.right-8 {
-  right: 2rem;
-}
-
-.top-8 {
-  top: 2rem;
 }
 
 .top-0 {
@@ -786,32 +774,16 @@ video {
   height: 24rem;
 }
 
+.h-\[464px\] {
+  height: 464px;
+}
+
 .h-\[var\(--radix-select-trigger-height\)\] {
   height: var(--radix-select-trigger-height);
 }
 
 .h-px {
   height: 1px;
-}
-
-.h-\[600px\] {
-  height: 600px;
-}
-
-.h-\[384px\] {
-  height: 384px;
-}
-
-.h-\[416px\] {
-  height: 416px;
-}
-
-.h-\[448px\] {
-  height: 448px;
-}
-
-.h-\[464px\] {
-  height: 464px;
 }
 
 .w-10 {
@@ -830,6 +802,10 @@ video {
   width: 1rem;
 }
 
+.w-64 {
+  width: 16rem;
+}
+
 .w-9 {
   width: 2.25rem;
 }
@@ -845,14 +821,6 @@ video {
 
 .w-full {
   width: 100%;
-}
-
-.w-72 {
-  width: 18rem;
-}
-
-.w-64 {
-  width: 16rem;
 }
 
 .min-w-\[8rem\] {
@@ -992,12 +960,6 @@ video {
   margin-bottom: calc(1rem * var(--tw-space-y-reverse));
 }
 
-.space-y-6 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-y-reverse: 0;
-  margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
-}
-
 .divide-y > :not([hidden]) ~ :not([hidden]) {
   --tw-divide-y-reverse: 0;
   border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
@@ -1057,10 +1019,6 @@ video {
 
 .rounded-xl {
   border-radius: 0.75rem;
-}
-
-.rounded {
-  border-radius: 0.25rem;
 }
 
 .border {
@@ -1195,9 +1153,8 @@ video {
   padding-bottom: 1.5rem;
 }
 
-.py-8 {
-  padding-top: 2rem;
-  padding-bottom: 2rem;
+.pb-2 {
+  padding-bottom: 0.5rem;
 }
 
 .pb-4 {
@@ -1216,20 +1173,16 @@ video {
   padding-right: 2rem;
 }
 
-.pt-6 {
-  padding-top: 1.5rem;
-}
-
-.pb-2 {
-  padding-bottom: 0.5rem;
+.pt-0 {
+  padding-top: 0px;
 }
 
 .pt-2 {
   padding-top: 0.5rem;
 }
 
-.pt-0 {
-  padding-top: 0px;
+.pt-6 {
+  padding-top: 1.5rem;
 }
 
 .text-left {
@@ -1258,11 +1211,6 @@ video {
   line-height: 2.25rem;
 }
 
-.text-4xl {
-  font-size: 2.25rem;
-  line-height: 2.5rem;
-}
-
 .text-base {
   font-size: 1rem;
   line-height: 1.5rem;
@@ -1278,14 +1226,14 @@ video {
   line-height: 1.25rem;
 }
 
-.text-xs {
-  font-size: 0.75rem;
-  line-height: 1rem;
-}
-
 .text-xl {
   font-size: 1.25rem;
   line-height: 1.75rem;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
 }
 
 .font-bold {
@@ -1346,6 +1294,11 @@ video {
   color: rgb(31 41 55 / var(--tw-text-opacity, 1));
 }
 
+.text-gray-900 {
+  --tw-text-opacity: 1;
+  color: rgb(17 24 39 / var(--tw-text-opacity, 1));
+}
+
 .text-slate-900 {
   --tw-text-opacity: 1;
   color: rgb(15 23 42 / var(--tw-text-opacity, 1));
@@ -1356,17 +1309,24 @@ video {
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
 
-.text-gray-900 {
-  --tw-text-opacity: 1;
-  color: rgb(17 24 39 / var(--tw-text-opacity, 1));
-}
-
 .underline-offset-4 {
   text-underline-offset: 4px;
 }
 
 .opacity-50 {
   opacity: 0.5;
+}
+
+.shadow {
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-\[0_2px_8px_rgba\(0\2c 0\2c 0\2c 0\.08\)\] {
+  --tw-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  --tw-shadow-colored: 0 2px 8px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .shadow-lg {
@@ -1384,18 +1344,6 @@ video {
 .shadow-sm {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.shadow {
-  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.shadow-\[0_2px_8px_rgba\(0\2c 0\2c 0\2c 0\.08\)\] {
-  --tw-shadow: 0 2px 8px rgba(0,0,0,0.08);
-  --tw-shadow-colored: 0 2px 8px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -1582,11 +1530,6 @@ video {
     margin-bottom: calc(0px * var(--tw-space-y-reverse));
   }
 
-  .sm\:px-6 {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-  }
-
   .sm\:pl-2\.5 {
     padding-left: 0.625rem;
   }
@@ -1597,12 +1540,6 @@ video {
 }
 
 @media (min-width: 768px) {
-  .md\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
-    --tw-space-y-reverse: 0;
-    margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
-    margin-bottom: calc(2rem * var(--tw-space-y-reverse));
-  }
-
   .md\:px-6 {
     padding-left: 1.5rem;
     padding-right: 1.5rem;
@@ -1617,99 +1554,9 @@ video {
 }
 
 @media (prefers-color-scheme: dark) {
-  .dark\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
-    --tw-divide-opacity: 1;
-    border-color: rgb(55 65 81 / var(--tw-divide-opacity, 1));
-  }
-
-  .dark\:border-blue-400 {
-    --tw-border-opacity: 1;
-    border-color: rgb(96 165 250 / var(--tw-border-opacity, 1));
-  }
-
-  .dark\:border-gray-600 {
-    --tw-border-opacity: 1;
-    border-color: rgb(75 85 99 / var(--tw-border-opacity, 1));
-  }
-
-  .dark\:border-gray-700 {
-    --tw-border-opacity: 1;
-    border-color: rgb(55 65 81 / var(--tw-border-opacity, 1));
-  }
-
-  .dark\:bg-gray-800 {
-    --tw-bg-opacity: 1;
-    background-color: rgb(31 41 55 / var(--tw-bg-opacity, 1));
-  }
-
-  .dark\:bg-gray-800\/80 {
-    background-color: rgb(31 41 55 / 0.8);
-  }
-
-  .dark\:bg-gray-900 {
-    --tw-bg-opacity: 1;
-    background-color: rgb(17 24 39 / var(--tw-bg-opacity, 1));
-  }
-
-  .dark\:bg-gray-900\/80 {
-    background-color: rgb(17 24 39 / 0.8);
-  }
-
-  .dark\:text-blue-400 {
-    --tw-text-opacity: 1;
-    color: rgb(96 165 250 / var(--tw-text-opacity, 1));
-  }
-
-  .dark\:text-gray-100 {
-    --tw-text-opacity: 1;
-    color: rgb(243 244 246 / var(--tw-text-opacity, 1));
-  }
-
-  .dark\:text-gray-200 {
-    --tw-text-opacity: 1;
-    color: rgb(229 231 235 / var(--tw-text-opacity, 1));
-  }
-
-  .dark\:text-gray-300 {
-    --tw-text-opacity: 1;
-    color: rgb(209 213 219 / var(--tw-text-opacity, 1));
-  }
-
   .dark\:text-gray-400 {
     --tw-text-opacity: 1;
     color: rgb(156 163 175 / var(--tw-text-opacity, 1));
-  }
-
-  .dark\:text-gray-500 {
-    --tw-text-opacity: 1;
-    color: rgb(107 114 128 / var(--tw-text-opacity, 1));
-  }
-
-  .dark\:text-slate-50 {
-    --tw-text-opacity: 1;
-    color: rgb(248 250 252 / var(--tw-text-opacity, 1));
-  }
-
-  .dark\:hover\:bg-gray-700:hover {
-    --tw-bg-opacity: 1;
-    background-color: rgb(55 65 81 / var(--tw-bg-opacity, 1));
-  }
-
-  .dark\:hover\:bg-gray-800\/50:hover {
-    background-color: rgb(31 41 55 / 0.5);
-  }
-
-  .dark\:hover\:text-gray-100:hover {
-    --tw-text-opacity: 1;
-    color: rgb(243 244 246 / var(--tw-text-opacity, 1));
-  }
-
-  .dark\:data-\[state\=selected\]\:bg-blue-900\/50[data-state="selected"] {
-    background-color: rgb(30 58 138 / 0.5);
-  }
-
-  .dark\:data-\[state\=selected\]\:hover\:bg-blue-800\/50:hover[data-state="selected"] {
-    background-color: rgb(30 64 175 / 0.5);
   }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ waitress==2.1.2
 Flask-SQLAlchemy
 python-dateutil
 Flask-Migrate
+playwright-stealth


### PR DESCRIPTION
This commit replaces the placeholder data in the dashboard's prospects table with actual data fetched from the backend, including fully functional pagination.

Key changes:

Backend (`app` directory):
- Added `get_prospects_paginated` function to `database/crud.py` to retrieve prospects from the database with offset and limit.
- Created a new API endpoint `/api/prospects` in `api/prospects.py` that serves paginated prospect data (including total count and total pages).
- Registered the new prospects API blueprint in `app/__init__.py`.
- Added `playwright-stealth` to `requirements.txt` (discovered during testing).

Frontend (`frontend-react` directory, specifically `src/pages/Dashboard.tsx`):
- Updated the `Prospect` TypeScript interface to match the actual data structure from the backend.
- Modified the `fetchProspects` function to call the new `/api/prospects` endpoint.
- Removed the mock `fetchProspectCount` and updated the prospect count display to use the total count from the `fetchProspects` response.
- Updated the table column definitions (`title`, `agency`, `source_name`, `release_date`) to match the new data fields and provide appropriate cell rendering (including null handling and date formatting).

The changes ensure that the dashboard now displays a live, paginated view of the prospects database without altering the existing table stylization.